### PR TITLE
Add web socket transport sender hostname verification

### DIFF
--- a/components/mediation/transports/org.wso2.micro.integrator.websocket.transport/src/main/java/org/wso2/micro/integrator/websocket/transport/WebsocketConstants.java
+++ b/components/mediation/transports/org.wso2.micro.integrator.websocket.transport/src/main/java/org/wso2/micro/integrator/websocket/transport/WebsocketConstants.java
@@ -53,6 +53,7 @@ public class WebsocketConstants {
 
     public static final String WEBSOCKET_CUSTOM_HEADER_PREFIX = "websocket.custom.header.";
     public static final String WEBSOCKET_CUSTOM_HEADER_CONFIG = "ws.custom.header";
+    public static final String WEBSOCKET_HOSTNAME_VERIFICATION_CONFIG = "ws.client.enable.hostname.verification";
 
     public static final String CONNECTION_TERMINATE = "connection.terminate";
 


### PR DESCRIPTION
Adding the following parameter to the WSS transport sender in the axis2.xml will enable hostname verification for the web socket transport sender.
```
<parameter name="ws.client.enable.hostname.verification" locked="false">true</parameter>
```

Porting https://github.com/wso2/carbon-mediation/pull/1692