### PR TITLE
Handle keys starting with `resources:...` while resolving registry URI

### DIFF
--- a/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistry.java
+++ b/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistry.java
@@ -1035,6 +1035,10 @@ public class MicroIntegratorRegistry extends AbstractRegistry {
                 registryRoot = localRegistry;
                 resourcePath = key.substring(MicroIntegratorRegistryConstants.LOCAL_REGISTRY_PREFIX.length());
 
+            } else if (key.startsWith(MicroIntegratorRegistryConstants.RESOURCES_PREFIX)) {
+                registryRoot = govRegistry;
+                resourcePath = MicroIntegratorRegistryConstants.MI_RESOURCES_DIRECTORY_NAME + URL_SEPARATOR +
+                        key.substring(MicroIntegratorRegistryConstants.RESOURCES_PREFIX.length());
             } else {
                 registryRoot = govRegistry;
                 resourcePath = key;

--- a/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistryConstants.java
+++ b/components/mediation/registry/org.wso2.micro.integrator.registry/src/main/java/org/wso2/micro/integrator/registry/MicroIntegratorRegistryConstants.java
@@ -45,11 +45,12 @@ public class MicroIntegratorRegistryConstants {
     public static final String PROTOCOL_HTTPS = "https";
     public static final String FILE_PROTOCOL_PREFIX = "file:";
 
-
+    public static final String RESOURCES_PREFIX = "resources:";
     public static final String CONFIG_REGISTRY_PREFIX = "conf:";
     public static final String GOVERNANCE_REGISTRY_PREFIX = "gov:";
     public static final String LOCAL_REGISTRY_PREFIX = "local:";
 
+    public static final String MI_RESOURCES_DIRECTORY_NAME = "mi-resources";
     public static final String CONFIG_DIRECTORY_NAME = "config";
     public static final String GOVERNANCE_DIRECTORY_NAME = "governance";
     public static final String LOCAL_DIRECTORY_NAME = "local";


### PR DESCRIPTION
## Purpose
With the updated resource structure, there are key references begin with `resources:...`. These keys have to be mapped to the  directory `registry/governance/mi-resources` 