### PR TITLE
Add capability to configure privateStores

### DIFF
--- a/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/core/Constants.java
+++ b/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/core/Constants.java
@@ -40,6 +40,10 @@ public class Constants {
     public static final String SERVER_PRIMARY_KEYSTORE_KEY_ALIAS = "Security.KeyStore.KeyAlias";
     public static final String SERVER_PRIVATE_KEY_PASSWORD = "Security.KeyStore.KeyPassword";
     public static final String SERVER_PRIMARY_KEYSTORE_TYPE = "Security.KeyStore.Type";
+    public static final String SERVER_PRIVATE_STORE_CONFIG = "keystore.secondary";
+    public static final String SERVER_PRIVATE_KEYSTORE_TYPE = "type";
+    public static final String SERVER_PRIVATE_KEYSTORE_FILE = "file_name";
+    public static final String SERVER_PRIVATE_KEYSTORE_PASSWORD = "password";
 
     //Internal key store which is used for encryption and decryption purpose
     public static final String SERVER_INTERNAL_KEYSTORE_FILE = "Security.InternalKeyStore.Location";

--- a/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/integrator/core/services/CarbonServerConfigurationService.java
+++ b/components/org.wso2.micro.integrator.core/src/main/java/org/wso2/micro/integrator/core/services/CarbonServerConfigurationService.java
@@ -528,6 +528,10 @@ public class CarbonServerConfigurationService {
 		return secretResolver.resolve("Carbon." + key);
 	}
 
+	public String getResolvedValue(String key) {
+		return secretResolver.resolve(key);
+	}
+
 	/**
 	 * Take the WSO2 server version from the carbon.xml file.
 	 *


### PR DESCRIPTION
## Purpose
Issue was MI server is always using its Primary Keystore for signing and signature verification purposes in WS Security for “Non Repudiation” scenario regardless of the Keystores and Truststores which are provided via the Rampart configurations. Fixed it by giving the capability to add private stores via rampart and using them.

Sample deployment.toml config
```
[[keystore.secondary]]
file_name = "repository/resources/security/newkeystore.jks"
password = "xxx"
type = "JKS"

[[keystore.secondary]]
file_name = "repository/resources/security/newkeystoreforsignature.jks"
password = "$secret{key_pass_2}"
type = "JKS"

[[keystore.secondary]]
file_name = "repository/resources/security/wso2carbonold.jks"
password = "$secret{key_pass_2}"
type = "JKS"
```

Fixes: https://github.com/wso2/micro-integrator/issues/3412