### PR TITLE
Improve CAppDeployer to deploy extracted carbon applications during server startup

### DIFF
--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/AppDeployerServiceComponent.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/AppDeployerServiceComponent.java
@@ -166,6 +166,7 @@ public class AppDeployerServiceComponent {
         // Initialize CApp deployer here
         CappDeployer cappDeployer = new CappDeployer();
         cappDeployer.setDirectory(artifactRepoPath + DeploymentConstants.CAPP_DIR_NAME);
+        cappDeployer.setAppsDirectory(artifactRepoPath + DeploymentConstants.APPS_DIR_NAME);
         cappDeployer.setSecretCallbackHandlerService(secretCallbackHandlerService);
         cappDeployer.init(configCtx);
 
@@ -176,6 +177,8 @@ public class AppDeployerServiceComponent {
         cappDeployer.registerDeploymentHandler(new DataSourceCappDeployer());
         cappDeployer.registerDeploymentHandler(new DefaultAppDeployer());
         cappDeployer.registerDeploymentHandler(new SynapseAppDeployer());
+        // deploy capps in the apps directory during the server startup
+        cappDeployer.deployCarbonAppsDirectory();
 
         //Add the deployer to deployment engine. This should be done after registering the deployment handlers.
         deploymentEngine.addDeployer(cappDeployer, artifactRepoPath + DeploymentConstants.CAPP_DIR_NAME,

--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/DeploymentConstants.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/DeploymentConstants.java
@@ -21,6 +21,7 @@ package org.wso2.micro.integrator.initializer.deployment;
 public class DeploymentConstants {
 
     public static final String CAPP_DIR_NAME = "carbonapps";
+    public static final String APPS_DIR_NAME = "apps";
     public static final String DSS_DIR_NAME = "dataservices";
     public static final String USER_STORE_DIR_NAME = "userstores";
     public static final String EVENT_STREAMS_DIR_NAME = "eventstreams";

--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/application/deployer/CappDeployer.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/application/deployer/CappDeployer.java
@@ -17,7 +17,6 @@
  */
 package org.wso2.micro.integrator.initializer.deployment.application.deployer;
 
-import com.google.gson.JsonObject;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.OMException;
 import org.apache.axiom.om.impl.builder.StAXOMBuilder;
@@ -85,6 +84,8 @@ public class CappDeployer extends AbstractDeployer {
      */
     private String cAppDir;
 
+    private String appsDir;
+
     /**
      * Carbon application file directory (i.e. 'car').
      */
@@ -106,6 +107,7 @@ public class CappDeployer extends AbstractDeployer {
     private SecretCallbackHandlerService secretCallbackHandlerService;
 
     public void init(ConfigurationContext configurationContext) {
+
         if (log.isDebugEnabled()) {
             log.debug("Initializing Capp Deployer..");
         }
@@ -124,10 +126,17 @@ public class CappDeployer extends AbstractDeployer {
     }
 
     public void setDirectory(String cAppDir) {
+
         this.cAppDir = cAppDir;
     }
 
+    public void setAppsDirectory(String appsDir) {
+
+        this.appsDir = appsDir;
+    }
+
     public void setExtension(String extension) {
+
         this.extension = extension;
     }
 
@@ -150,7 +159,7 @@ public class CappDeployer extends AbstractDeployer {
     }
 
     /**
-     * Deploy synapse artifacts in a carbon application.
+     * Deploy synapse artifacts in a .car file.
      *
      * @param artifactPath - file path to be processed
      * @throws CarbonException - error while building
@@ -171,11 +180,34 @@ public class CappDeployer extends AbstractDeployer {
         }
 
         String targetCAppPath = cAppDirectory + File.separator + cAppName;
+        String extractedPath = extractCarbonApplication(targetCAppPath, cAppName, axisConfig);
+        deployCarbonApplications(cAppName, targetCAppPath, extractedPath);
+    }
+
+    /**
+     * Deploy synapse artifacts in a carbon application under apps directory.
+     *
+     * @param artifactPath - file path to be processed
+     * @throws CarbonException - error while building
+     */
+    public void deployApps(String artifactPath) throws CarbonException {
+
+        String archPathToProcess = AppDeployerUtils.formatPath(artifactPath);
+        String cAppName = archPathToProcess.substring(archPathToProcess.lastIndexOf('/') + 1);
+        String targetCAppPath;
+        if (!artifactPath.endsWith(File.separator)) {
+            targetCAppPath = artifactPath + File.separator;
+        } else {
+            targetCAppPath = artifactPath;
+        }
+        deployCarbonApplications(cAppName, targetCAppPath, targetCAppPath);
+    }
+
+    private void deployCarbonApplications(String cAppName, String cAppPath, String targetCAppPath) throws CarbonException {
+
         CarbonApplication currentApp = null;
-
         try {
-            currentApp = buildCarbonApplication(targetCAppPath, cAppName, axisConfig);
-
+            currentApp = buildCarbonApplication(cAppPath, targetCAppPath, cAppName, axisConfig);
             if (currentApp != null) {
                 // deploy sub artifacts of this cApp
                 this.searchArtifacts(currentApp.getExtractedPath(), currentApp);
@@ -188,8 +220,8 @@ public class CappDeployer extends AbstractDeployer {
                     }
                 } else {
                     log.error("Some dependencies were not satisfied in cApp:" + currentApp.getAppNameWithVersion() +
-                                      "Check whether all dependent artifacts are included in cApp file: " +
-                                      targetCAppPath);
+                            "Check whether all dependent artifacts are included in cApp file: " +
+                            targetCAppPath);
 
                     deleteExtractedCApp(currentApp.getExtractedPath());
                     // Validate synapse config to remove half added swagger definitions in the case of a faulty CAPP.
@@ -201,7 +233,7 @@ public class CappDeployer extends AbstractDeployer {
                 currentApp.setDeploymentCompleted(true);
                 this.addCarbonApp(currentApp);
                 log.info("Successfully Deployed Carbon Application : " + currentApp.getAppNameWithVersion() +
-                                 AppDeployerUtils.getTenantIdLogString(AppDeployerUtils.getTenantId()));
+                        AppDeployerUtils.getTenantIdLogString(AppDeployerUtils.getTenantId()));
             }
         } catch (DeploymentException e) {
             log.error("Error occurred while deploying the Carbon application: " + cAppName
@@ -220,39 +252,63 @@ public class CappDeployer extends AbstractDeployer {
         }
     }
 
+    public void deployCarbonAppsDirectory() {
+
+        File cAppDirectory = new File(this.appsDir);
+        File[] cAppFiles = cAppDirectory.listFiles();
+        if (cAppFiles == null) {
+            return;
+        }
+        for (File cAppFile : cAppFiles) {
+            if (cAppFile.isDirectory()) {
+                try {
+                    deployApps(cAppFile.getAbsolutePath());
+                } catch (CarbonException e) {
+                    log.error("Error while deploying carbon application " + cAppFile.getAbsolutePath(), e);
+                }
+            }
+        }
+    }
+
+    private String extractCarbonApplication(String targetCAppPath, String cAppName,
+                                                               AxisConfiguration axisConfig) throws CarbonException {
+
+        return AppDeployerUtils.extractCarbonApp(targetCAppPath);
+    }
+
     /**
      * Builds the carbon application from app configuration created using the artifacts.xml path.
      *
-     * @param targetCAppPath - path to target carbon application
-     * @param cAppName       - name of the carbon application
-     * @param axisConfig     - AxisConfiguration instance
+     * @param cappPath             - path of the carbon application
+     * @param extractedCAppDirectory - path to extracted carbon application
+     * @param cAppName             - name of the carbon application
+     * @param axisConfig           - AxisConfiguration instance
      * @return - CarbonApplication instance if successfull. otherwise null..
      * @throws CarbonException - error while building
      */
-    private CarbonApplication buildCarbonApplication(String targetCAppPath, String cAppName,
+    private CarbonApplication buildCarbonApplication(String cappPath, String extractedCAppDirectory, String cAppName,
                                                      AxisConfiguration axisConfig) throws CarbonException {
-        String tempExtractedDirPath = AppDeployerUtils.extractCarbonApp(targetCAppPath);
 
         // Build the app configuration by providing the artifacts.xml path
-        ApplicationConfiguration appConfig = new ApplicationConfiguration(tempExtractedDirPath);
+        ApplicationConfiguration appConfig = new ApplicationConfiguration(extractedCAppDirectory);
 
         // If we don't have features (artifacts) for this server, ignore
         if (appConfig.getApplicationArtifact().getDependencies().isEmpty()) {
             log.warn("No artifacts found to be deployed in this server. " +
-                             "Ignoring Carbon Application : " + cAppName);
+                    "Ignoring Carbon Application : " + cAppName);
             return null;
         }
 
         CarbonApplication carbonApplication = new CarbonApplication();
-        carbonApplication.setAppFilePath(targetCAppPath);
-        carbonApplication.setExtractedPath(tempExtractedDirPath);
+        carbonApplication.setAppFilePath(cappPath);
+        carbonApplication.setExtractedPath(extractedCAppDirectory);
         carbonApplication.setAppConfig(appConfig);
 
         // Set App Name
         String appName = appConfig.getAppName();
         if (appName == null) {
             log.warn("No application name found in Carbon Application : " + cAppName + ". Using " +
-                             "the file name as the application name");
+                    "the file name as the application name");
             appName = cAppName.substring(0, cAppName.lastIndexOf('.'));
         }
         // to support multiple capp versions, we check app name with version

--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/application/deployer/CappDeployer.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/application/deployer/CappDeployer.java
@@ -180,7 +180,7 @@ public class CappDeployer extends AbstractDeployer {
         }
 
         String targetCAppPath = cAppDirectory + File.separator + cAppName;
-        String extractedPath = extractCarbonApplication(targetCAppPath, cAppName, axisConfig);
+        String extractedPath = extractCarbonApplication(targetCAppPath);
         deployCarbonApplications(cAppName, targetCAppPath, extractedPath);
     }
 
@@ -194,12 +194,7 @@ public class CappDeployer extends AbstractDeployer {
 
         String archPathToProcess = AppDeployerUtils.formatPath(artifactPath);
         String cAppName = archPathToProcess.substring(archPathToProcess.lastIndexOf('/') + 1);
-        String targetCAppPath;
-        if (!artifactPath.endsWith(File.separator)) {
-            targetCAppPath = artifactPath + File.separator;
-        } else {
-            targetCAppPath = artifactPath;
-        }
+        String targetCAppPath = artifactPath.endsWith(File.separator) ? artifactPath : artifactPath + File.separator;
         deployCarbonApplications(cAppName, targetCAppPath, targetCAppPath);
     }
 
@@ -256,7 +251,7 @@ public class CappDeployer extends AbstractDeployer {
 
         File cAppDirectory = new File(this.appsDir);
         File[] cAppFiles = cAppDirectory.listFiles();
-        if (cAppFiles == null) {
+        if (cAppFiles.length == 0) {
             return;
         }
         for (File cAppFile : cAppFiles) {
@@ -270,8 +265,14 @@ public class CappDeployer extends AbstractDeployer {
         }
     }
 
-    private String extractCarbonApplication(String targetCAppPath, String cAppName,
-                                                               AxisConfiguration axisConfig) throws CarbonException {
+    /**
+     * Extracts the carbon application to the tmp/carbonapps directory.
+     *
+     * @param targetCAppPath - path of the carbon application
+     * @return - path to the extracted carbon application
+     * @throws CarbonException - error while extracting
+     */
+    private String extractCarbonApplication(String targetCAppPath) throws CarbonException {
 
         return AppDeployerUtils.extractCarbonApp(targetCAppPath);
     }

--- a/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/synapse/deployer/SynapseAppDeployer.java
+++ b/components/org.wso2.micro.integrator.initializer/src/main/java/org/wso2/micro/integrator/initializer/deployment/synapse/deployer/SynapseAppDeployer.java
@@ -28,6 +28,7 @@ import org.apache.axis2.deployment.Deployer;
 import org.apache.axis2.deployment.DeploymentEngine;
 import org.apache.axis2.deployment.DeploymentException;
 import org.apache.axis2.deployment.repository.util.DeploymentFileData;
+import org.apache.axis2.deployment.util.Utils;
 import org.apache.axis2.description.Parameter;
 import org.apache.axis2.engine.AxisConfiguration;
 import org.apache.commons.io.FileUtils;
@@ -60,6 +61,7 @@ import org.apache.synapse.deployers.TemplateDeployer;
 import org.apache.synapse.endpoints.Endpoint;
 import org.apache.synapse.endpoints.Template;
 import org.apache.synapse.inbound.InboundEndpoint;
+import org.apache.synapse.libraries.LibClassLoader;
 import org.apache.synapse.libraries.imports.SynapseImport;
 import org.apache.synapse.libraries.model.Library;
 import org.apache.synapse.libraries.util.LibDeployerUtils;
@@ -89,6 +91,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.Method;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -129,6 +132,10 @@ public class SynapseAppDeployer implements AppDeploymentHandler {
         List<Artifact.Dependency> artifacts = carbonApp.getAppConfig().getApplicationArtifact()
                 .getDependencies();
 
+        if (carbonApp.getClassLoader() == null) {
+            carbonApp.setClassLoader(new LibClassLoader(new URL[0], Utils.getClassLoader
+                    (LibDeployerUtils.class.getClassLoader(), carbonApp.getExtractedPath(), false)));
+        }
         deployClassMediators(artifacts, axisConfig, carbonApp);
         deploySynapseLibrary(artifacts, axisConfig, carbonApp);
         Map<String, List<Artifact.Dependency>> artifactTypeMap = getOrderedArtifactsMap(artifacts);

--- a/distribution/src/assembly/bin.xml
+++ b/distribution/src/assembly/bin.xml
@@ -334,6 +334,13 @@
                 <exclude>empty.txt</exclude>
             </excludes>
         </fileSet>
+        <fileSet>
+            <directory>src/resources/capps</directory>
+            <outputDirectory>wso2mi-${pom.version}/repository/deployment/server/apps</outputDirectory>
+            <excludes>
+                <exclude>empty.txt</exclude>
+            </excludes>
+        </fileSet>
 
         <fileSet>
             <directory>src/resources/security</directory>


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

This PR introduces a new directory called `apps` inside `repository/deployment/server`. This is to facilitate deploying carbon applications in a read-only environment (eg: Read only containers). This way, the carbon applications will be deployed as it is during server startup. Please note that hot deployment is not supported for this.