### PR TITLE
Downgrade org.json.wso2:json version to fix Invalid CEN header

### DIFF
--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -842,7 +842,7 @@
         <groovy.version>1.1-rc-1</groovy.version>
         <org.jruby.version>1.3.0</org.jruby.version>
         <opensaml.version>3.3.1</opensaml.version>
-        <org.wso2.json.version>3.0.0.wso2v5</org.wso2.json.version>
+        <org.wso2.json.version>3.0.0.wso2v4</org.wso2.json.version>
         <maven.model.version>3.3.9</maven.model.version>
         <testng.suiteXml.location>src/test/resources/testng.xml</testng.suiteXml.location>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1662,7 +1662,7 @@
         <saml.common.util.version.range>[1.0.0,2.0.0)</saml.common.util.version.range>
         <bouncycastle.orbit.version>1.78.1.wso2v1</bouncycastle.orbit.version>
         <orbit.version.poi.ooxml>5.3.0.wso2v1</orbit.version.poi.ooxml>
-        <org.wso2.json.version>3.0.0.wso2v5</org.wso2.json.version>
+        <org.wso2.json.version>3.0.0.wso2v4</org.wso2.json.version>
         <version.equinox.http.servlet>1.1.400.v20130418-1354</version.equinox.http.servlet>
         <version.tomcat>9.0.98</version.tomcat>
         <orbit.version.tomcat.jsp.api>${version.tomcat}.wso2v1</orbit.version.tomcat.jsp.api>

--- a/product-scenarios/pom.xml
+++ b/product-scenarios/pom.xml
@@ -66,7 +66,7 @@
         <automation.framework.utils.version>4.5.0</automation.framework.utils.version>
         <carbon.p2.plugin.version>1.5.8</carbon.p2.plugin.version>
         <httpclient.version>4.3.2</httpclient.version>
-        <org.wso2.json.version>3.0.0.wso2v5</org.wso2.json.version>
+        <org.wso2.json.version>3.0.0.wso2v4</org.wso2.json.version>
         <awaitility.version>3.1.2</awaitility.version>
         <commons.lang.version>2.6.0.wso2v1</commons.lang.version>
         <maven.surefire.version>2.12.4</maven.surefire.version>


### PR DESCRIPTION
## Purpose

org.json.wso2:json:3.0.0.wso2v5 fails with the following compilation error in Java 11.0.26. 

```
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] error reading /Users/wso2/.m2/repository/org/json/wso2/json/3.0.0.wso2v5/json-3.0.0.wso2v5.jar; Invalid CEN header (invalid extra data field size for tag: 0xbdbf at 627)
```