### PR TITLE
Fix all carbon_home files deleted after tmp folder deletion and restart

### DIFF
--- a/distribution/src/scripts/micro-integrator.bat
+++ b/distribution/src/scripts/micro-integrator.bat
@@ -201,10 +201,12 @@ cd %CARBON_HOME%
 
 rem ------------------ Remove tmp folder on startup -----------------------------
 set TMP_DIR=%CARBON_HOME%\tmp
-cd "%TMP_DIR%"
-del *.* /s /q > nul
-FOR /d %%G in ("*.*") DO rmdir %%G /s /q
-cd ..
+if exist "%TMP_DIR%" (
+    cd "%TMP_DIR%"
+    del *.* /s /q > nul
+    FOR /d %%G in ("*.*") DO rmdir %%G /s /q
+    cd ..
+)
 
 rem ---------- Add jars to classpath --c _CLASSPATH%
 


### PR DESCRIPTION
## Purpose
Fix all carbon_home files deleted after tmp folder deletion and restart. 
Fixes: https://github.com/wso2/product-micro-integrator/issues/3145
