### PR TITLE
Include Correlation ID, LDAP, and JDBC logs when correlation logs are enabled with management API

### DIFF
--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ConfigsResource.java
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/src/main/java/org/wso2/micro/integrator/management/apis/ConfigsResource.java
@@ -21,11 +21,14 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.synapse.MessageContext;
 import org.apache.synapse.commons.json.JsonUtil;
+import org.apache.synapse.commons.logger.ContextAwareLogger;
 import org.apache.synapse.config.SynapseConfiguration;
 import org.apache.synapse.transport.passthru.config.PassThroughCorrelationConfigDataHolder;
 import org.json.JSONObject;
 import org.wso2.micro.integrator.management.apis.security.handler.SecurityUtils;
+import org.wso2.micro.integrator.ndatasource.rdbms.CorrelationLogInterceptor;
 import org.wso2.micro.integrator.security.user.api.UserStoreException;
+import org.wso2.micro.integrator.security.user.core.ldap.LDAPConnectionContext;
 
 import java.io.IOException;
 import java.util.HashSet;
@@ -127,6 +130,10 @@ public class ConfigsResource implements MiApiResource {
                 }
                 boolean enabled = Boolean.parseBoolean(configs.get(ENABLED).getAsString());
                 PassThroughCorrelationConfigDataHolder.setEnable(enabled);
+                ContextAwareLogger.setCorrelationLoggingEnabled(enabled);
+                LDAPConnectionContext.setCorrelationLoggingEnabled(enabled);
+                CorrelationLogInterceptor.setCorrelationLoggingEnabled(enabled);
+
                 JSONObject response = new JSONObject();
                 response.put(Constants.MESSAGE, "Successfully Updated Correlation Logs Status");
                 return response;

--- a/components/org.wso2.micro.integrator.ndatasource.rdbms/src/main/java/org/wso2/micro/integrator/ndatasource/rdbms/CorrelationLogInterceptor.java
+++ b/components/org.wso2.micro.integrator.ndatasource.rdbms/src/main/java/org/wso2/micro/integrator/ndatasource/rdbms/CorrelationLogInterceptor.java
@@ -49,6 +49,7 @@ public class CorrelationLogInterceptor extends AbstractQueryReport {
     private static final String BLACKLISTED_THREADS_SYSTEM_PROPERTY =
             "org.wso2.CorrelationLogInterceptor.BlacklistedThreads";
     private static final String DEFAULT_BLACKLISTED_THREAD = "MessageDeliveryTaskThreadPool";
+    private static boolean correlationLoggingEnabled = false;
     private List<String> blacklistedThreadList = new ArrayList<>();
 
     public CorrelationLogInterceptor() {
@@ -124,7 +125,7 @@ public class CorrelationLogInterceptor extends AbstractQueryReport {
     public Object createStatement(Object proxy, Method method, Object[] args, Object statement, long time) {
 
         try {
-            if (Boolean.parseBoolean(System.getProperty(CORRELATION_LOG_SYSTEM_PROPERTY))) {
+            if (Boolean.parseBoolean(System.getProperty(CORRELATION_LOG_SYSTEM_PROPERTY)) || correlationLoggingEnabled) {
                 return invokeProxy(method, args, statement, time);
             } else {
                 return statement;
@@ -283,5 +284,9 @@ public class CorrelationLogInterceptor extends AbstractQueryReport {
             }
             return sb.toString();
         }
+    }
+    public static void setCorrelationLoggingEnabled(boolean correlationLoggingEnabled) {
+
+        CorrelationLogInterceptor.correlationLoggingEnabled = correlationLoggingEnabled;
     }
 }

--- a/components/org.wso2.micro.integrator.security/src/main/java/org/wso2/micro/integrator/security/user/core/ldap/LDAPConnectionContext.java
+++ b/components/org.wso2.micro.integrator.security/src/main/java/org/wso2/micro/integrator/security/user/core/ldap/LDAPConnectionContext.java
@@ -77,6 +77,7 @@ public class LDAPConnectionContext {
     private static final int CORRELATION_LOG_INITIALIZATION_ARGS_LENGTH = 0;
     private static final String CORRELATION_LOG_SEPARATOR = "|";
     private static final String CORRELATION_LOG_SYSTEM_PROPERTY = "enableCorrelationLogs";
+    private static boolean correlationLoggingEnabled = false;
     public static final String CIRCUIT_STATE_OPEN = "open";
     public static final String CIRCUIT_STATE_CLOSE = "close";
 
@@ -625,7 +626,7 @@ public class LDAPConnectionContext {
      */
     private DirContext getDirContext(Hashtable<?, ?> environment) throws NamingException {
 
-        if (Boolean.parseBoolean(System.getProperty(CORRELATION_LOG_SYSTEM_PROPERTY))) {
+        if (Boolean.parseBoolean(System.getProperty(CORRELATION_LOG_SYSTEM_PROPERTY)) || correlationLoggingEnabled) {
             final Class[] proxyInterfaces = new Class[]{DirContext.class};
             long start = System.currentTimeMillis();
 
@@ -662,7 +663,7 @@ public class LDAPConnectionContext {
     private LdapContext getLdapContext(Hashtable<?, ?> environment, Control[] connectionControls)
             throws NamingException, UserStoreException {
 
-        if (Boolean.parseBoolean(System.getProperty(CORRELATION_LOG_SYSTEM_PROPERTY))) {
+        if (Boolean.parseBoolean(System.getProperty(CORRELATION_LOG_SYSTEM_PROPERTY)) || correlationLoggingEnabled) {
             final Class[] proxyInterfaces = new Class[]{LdapContext.class};
             long start = System.currentTimeMillis();
 
@@ -839,5 +840,9 @@ public class LDAPConnectionContext {
             throw new UserStoreException("Error occurred while parsing ConnectionRetryDelay property value. value: "
                     + UserStoreConfigConstants.CONNECTION_RETRY_DELAY);
         }
+    }
+    public static void setCorrelationLoggingEnabled(boolean correlationLoggingEnabled) {
+
+        LDAPConnectionContext.correlationLoggingEnabled = correlationLoggingEnabled;
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -1622,7 +1622,7 @@
         <version.jaxb.api>2.4.0-b180830.0359</version.jaxb.api>
         <com.sun.jaxb.version>2.3.0</com.sun.jaxb.version>
         <com.sun.jaxb.impl.version>2.3.1</com.sun.jaxb.impl.version>
-        <synapse.version>4.0.0-wso2v215</synapse.version>
+        <synapse.version>4.0.0-wso2v216</synapse.version>
         <imp.pkg.version.synapse>[4.0.0, 4.0.1)</imp.pkg.version.synapse>
         <carbon.mediation.version>4.7.244</carbon.mediation.version>
         <carbon.crypto.version>1.1.3</carbon.crypto.version>


### PR DESCRIPTION
## Purpose

Include Correlation ID, LDAP, and JDBC logs when correlation logs are enabled with management API.
FIxes: https://github.com/wso2/product-micro-integrator/issues/3974