### PR TITLE
Revert try-with-resources for BufferedReader

### DIFF
--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/description/query/SQLQuery.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/description/query/SQLQuery.java
@@ -1683,24 +1683,20 @@ public class SQLQuery extends ExpressionQuery implements BatchRequestParticipant
              if (value == null) {
                  sqlQuery.setNull(i + 1, Types.CLOB);
              } else {
-                 try (BufferedReader reader = new BufferedReader(new StringReader(value))) {
-                     sqlQuery.setClob(i + 1, reader, value.length());
-                 } catch (IOException e) {
-                     throw new DataServiceFault(e, "Error processing parameter: " + paramName
-                             + ", Error: " + e.getMessage());
-                 }
+                 // Use of Try-with-resources is removed since it causes "Stream closed" error.
+                 // The JDBC driver will handle closing the stream after reading the data.
+                 sqlQuery.setClob(i + 1, new BufferedReader(new StringReader(value)),
+                         value.length());
              }
          } else if ("INOUT".equals(paramType)) {
              if (value == null) {
                  ((CallableStatement) sqlQuery).setNull(i + 1,
                                         Types.CLOB);
              } else {
-                 try (BufferedReader reader = new BufferedReader(new StringReader(value))) {
-                     ((CallableStatement) sqlQuery).setClob(i + 1, reader, value.length());
-                 } catch (IOException e) {
-                     throw new DataServiceFault(e, "Error processing parameter: " + paramName + ", Error: "
-                             + e.getMessage());
-                 }
+                 // Use of Try-with-resources is removed since it causes "Stream closed" error.
+                 // The JDBC driver will handle closing the stream after reading the data.
+                 ((CallableStatement) sqlQuery).setClob(i + 1,
+                         new BufferedReader(new StringReader(value)), value.length());
              }
              ((CallableStatement) sqlQuery).registerOutParameter(i + 1,
                                 Types.CLOB);


### PR DESCRIPTION
## Purpose

Reverting try-with-resources  for BufferedReader (Added with [1] to address Info level vulnerability) since it gets closed before the query executes, causing a Stream closed error. 

Fixes: https://github.com/wso2/product-micro-integrator/issues/3985

[1] https://github.com/wso2/product-micro-integrator/pull/3860