### PR TITLE
Fix JMS dur sub reconnection issue in MI cluster

### DIFF
--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSTask.java
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSTask.java
@@ -80,4 +80,17 @@ public class JMSTask extends InboundTask implements LocalTaskActionListener {
             logger.debug("Destroyed JMS task due to deletion of task: " + taskName);
         }
     }
+
+    /**
+     * {@inheritDoc}
+     * <p>
+     * Close connections of the JMS task upon pause.
+     *
+     * @param taskName the name of the task that was paused
+     */
+    @Override
+    public void notifyLocalTaskPause(String taskName) {
+        logger.info("Close connections of the JMS task upon pause of task: " + taskName);
+        jmsPollingConsumer.destroy();
+    }
 }

--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/rabbitmq/RabbitMQTask.java
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/rabbitmq/RabbitMQTask.java
@@ -56,4 +56,10 @@ public class RabbitMQTask extends OneTimeTriggerInboundTask implements LocalTask
         setReTrigger();
         rabbitMQConsumer.requestShutdown();
     }
+
+    @Override
+    public void notifyLocalTaskPause(String taskName) {
+        setReTrigger();
+        rabbitMQConsumer.requestShutdown();
+    }
 }

--- a/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/impl/AbstractQuartzTaskManager.java
+++ b/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/impl/AbstractQuartzTaskManager.java
@@ -174,6 +174,11 @@ public abstract class AbstractQuartzTaskManager implements TaskManager {
         String taskGroup = this.getTenantTaskGroup();
         try {
             this.getScheduler().pauseJob(new JobKey(taskName, taskGroup));
+            //notify the listeners of the task pause
+            LocalTaskActionListener listener = localTaskActionListeners.get(taskName);
+            if (null != listener) {
+                listener.notifyLocalTaskPause(taskName);
+            }
             log.info("Task temporarily paused: [" + this.getTaskType() + "][" + taskName + "]");
         } catch (SchedulerException e) {
             throw new TaskException("Error in temporarily pausing task with name: " + taskName,

--- a/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/impl/LocalTaskActionListener.java
+++ b/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/impl/LocalTaskActionListener.java
@@ -32,4 +32,11 @@ public interface LocalTaskActionListener {
      * @param taskName
      */
     void notifyLocalTaskRemoval(String taskName);
+
+    /**
+     * Method to notify when a local task is paused, it can be only due to pause.
+     *
+     * @param taskName
+     */
+    void notifyLocalTaskPause(String taskName);
 }


### PR DESCRIPTION

## Purpose
Resolved an issue in the MI cluster scenario where JMS durable subscribers failed to reconnect during rescheduling after a database connection failure. The problem occurred due to existing open connections blocking new connections. The fix involves properly closing JMS connections when tasks are paused, ensuring clean reconnections during recovery and maintaining reliable task execution in cluster environments.

Fixes: https://github.com/wso2/product-micro-integrator/issues/3652
