### PR TITLE
Handle NPE in MetricHandler.

### DIFF
--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpServerWorker.java
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/http/InboundHttpServerWorker.java
@@ -250,6 +250,7 @@ public class InboundHttpServerWorker extends ServerWorker {
         if (log.isDebugEnabled()) {
             log.debug("injecting message to sequence : " + endpoint.getInjectingSeq());
         }
+        synCtx.setProperty(SynapseConstants.INBOUND_ENDPOINT_NAME, endpoint.getName());
         synCtx.getEnvironment().injectMessage(synCtx, injectingSequence);
     }
 


### PR DESCRIPTION
## Purpose
Set the inbound endpoint name in the injectToMainSequence method to avoid NPE in MetricHandler. 
Fixes: https://github.com/wso2/product-micro-integrator/issues/4053