### PR TITLE
Return Odata count without $top, $skip, or $expand query options with a system property

### DIFF
--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/odata/ODataConstants.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/odata/ODataConstants.java
@@ -75,4 +75,5 @@ public class ODataConstants {
     public static final int LESS_THAN = -1;
     public static final int GREATER_THAN = 1;
     public static final String E_TAG = "E_TAG";
+    public static final String ODATA_COUNT_WITHOUT_PAGING = "odataCountWithoutPaging";
 }

--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/odata/StreamingEntityIterator.java
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/src/main/java/org/wso2/micro/integrator/dataservices/core/odata/StreamingEntityIterator.java
@@ -41,6 +41,11 @@ public class StreamingEntityIterator extends EntityIterator {
     public int entityCount;
 
     /**
+     * Number of applicable entries.
+     */
+    public int odataCount;
+
+    /**
      * Number of entries.
      */
     public int rowsCount;
@@ -132,6 +137,10 @@ public class StreamingEntityIterator extends EntityIterator {
 
     public List<Entity> getEntityList() {
         return entityList;
+    }
+    public int getOdataCount() {
+
+        return odataCount;
     }
 
     @Override


### PR DESCRIPTION
## Purpose

Return Odata count without $top, $skip, or $expand query options with the system property.
```
odataCountWithoutPaging = true
```
Fixes: https://github.com/wso2/product-micro-integrator/issues/4135
