### PR TITLE
Add graceful shutdown handling for proxy injection tasks only

### DIFF
--- a/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/TaskUtils.java
+++ b/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/TaskUtils.java
@@ -55,6 +55,8 @@ public class TaskUtils {
 
     private static SecretResolver secretResolver;
 
+    private static final long DEFAULT_MAX_WAIT_TIME = 180;
+
     public static Document convertToDocument(File file) throws TaskException {
         DocumentBuilderFactory fac = DocumentBuilderFactory.newInstance();
         fac.setNamespaceAware(true);
@@ -72,6 +74,27 @@ public class TaskUtils {
             throw new TaskException("Error in creating an XML document from file: " + e.getMessage(),
                                     TaskException.Code.CONFIG_ERROR, e);
         }
+    }
+
+    /**
+     * Retrieves the maximum wait time for shutdown from a system property.
+     * If the property is not set or is invalid, returns the default value.
+     *
+     * @return the maximum wait time in seconds
+     */
+    public static long getMaxWaitTimeInSeconds() {
+        String value = System.getProperty("gracefulShutdownTimeout");
+        if (value != null) {
+            try {
+                long parsed = Long.parseLong(value.trim());
+                if (parsed > 0) {
+                    return parsed;
+                }
+            } catch (NumberFormatException e) {
+               //ignore the exception and use default value
+            }
+        }
+        return DEFAULT_MAX_WAIT_TIME;
     }
 
     private static void secureLoadElement(Element element) throws CryptoException {

--- a/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/impl/QuartzCachedThreadPool.java
+++ b/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/src/main/java/org/wso2/micro/integrator/ntask/core/impl/QuartzCachedThreadPool.java
@@ -17,11 +17,15 @@
  */
 package org.wso2.micro.integrator.ntask.core.impl;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.quartz.SchedulerConfigException;
 import org.quartz.spi.ThreadPool;
+import org.wso2.micro.integrator.ntask.core.TaskUtils;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Quartz thread pool implementation which uses a cached thread executor service.
@@ -29,6 +33,7 @@ import java.util.concurrent.Executors;
 public class QuartzCachedThreadPool implements ThreadPool {
 
     private ExecutorService executor;
+    private static Log log = LogFactory.getLog(QuartzCachedThreadPool.class);
 
     @Override
     public int blockForAvailableThreads() {
@@ -47,6 +52,10 @@ public class QuartzCachedThreadPool implements ThreadPool {
 
     @Override
     public boolean runInThread(Runnable task) {
+        if (executor.isShutdown()) {
+            log.warn("Executor is shut down. Cannot accept new tasks.");
+            return false;
+        }
         this.executor.submit(task);
         return true;
     }
@@ -62,7 +71,20 @@ public class QuartzCachedThreadPool implements ThreadPool {
     @Override
     public void shutdown(boolean waitForJobsToComplete) {
         if (waitForJobsToComplete) {
+            log.info("Graceful scheduler shutdown initiated. Waiting for tasks to finish...");
             this.executor.shutdown();
+            try {
+                if (!executor.awaitTermination(TaskUtils.getMaxWaitTimeInSeconds(), TimeUnit.SECONDS)) {
+                    log.warn("Scheduler did not terminate in time. Forcing shutdown.");
+                    executor.shutdownNow();
+                } else {
+                    log.info("Scheduler terminated cleanly.");
+                }
+            } catch (InterruptedException e) {
+                log.warn("Scheduler shutdown interrupted. Forcing shutdown.");
+                executor.shutdownNow();
+                Thread.currentThread().interrupt();
+            }
         } else {
             this.executor.shutdownNow();
         }


### PR DESCRIPTION

## Purpose
Ensure graceful shutdown is applied only when the
MessageInjector injects into a proxy. Sequence-based injection executes asynchronously, and the Quartz
thread returns before mediation completes, making it unsuitable for reliable termination tracking.

This fix avoids incorrectly assuming task completion for sequence-based injections and prevents premature shutdown of the server while proxy flows are running.

Fixes: https://github.com/wso2/product-micro-integrator/issues/4148
