### PR TITLE
Prevent poll after destroy to avoid JMS recreation

### DIFF
--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSTask.java
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/src/main/java/org/wso2/carbon/inbound/endpoint/protocol/jms/JMSTask.java
@@ -96,6 +96,6 @@ public class JMSTask extends InboundTask implements LocalTaskActionListener {
 
     @Override
     public void notifyLocalTaskResume(String taskName) {
-        //ignore
+        jmsPollingConsumer.enablePolling();
     }
 }


### PR DESCRIPTION


## Purpose
Ensure poll() respects the destroyed state to avoid JMS resource recreation. This prevents durable subscription conflicts caused by racing threads where destroy() is invoked mid-poll.

A read-write lock is used to safely coordinate access to shared JMS state. This guarantees that destroy() can block new polls and complete cleanup before further polling resumes.

Fixes: https://github.com/wso2/product-micro-integrator/issues/4216