### PR TITLE
Add support for Configuring OTEL_RESOURCE_ATTRIBUTES in WSO2 MI.

### DIFF
--- a/distribution/src/resources/config-tool/templates/conf/synapse.properties.j2
+++ b/distribution/src/resources/config-tool/templates/conf/synapse.properties.j2
@@ -33,3 +33,7 @@ mediation.flow.statistics.event.clean.interval=15000
 {%for property in opentelemetry.properties %}
 opentelemetry.properties.{{property.name}} = {{property.value}}
 {% endfor %}
+
+{% if opentelemetry.resource_attributes %}
+opentelemetry.properties.resource_attributes={% for attribute in opentelemetry.resource_attributes %}{{ attribute.name }}={{ attribute.value }}{% if not loop.last %},{% endif %}{% endfor %}
+{% endif %}


### PR DESCRIPTION
Update synapse.properties.j2 file to add OTEL_RESOURCE_ATTRIBUTES 

fixes: https://github.com/wso2/product-micro-integrator/issues/4256