### PR TITLE
Fix NPE in CacheMediator while TRANSPORT_HEADERS removed

### DIFF
--- a/components/business-adaptors/org.wso2.micro.integrator.business.messaging.hl7/pom.xml
+++ b/components/business-adaptors/org.wso2.micro.integrator.business.messaging.hl7/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>business-adaptors</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/business-adaptors/pom.xml
+++ b/components/business-adaptors/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>mi-component-parent</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/crypto-service/org.wso2.micro.integrator.crypto.impl/pom.xml
+++ b/components/crypto-service/org.wso2.micro.integrator.crypto.impl/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>crypto-service</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/crypto-service/org.wso2.micro.integrator.crypto.provider/pom.xml
+++ b/components/crypto-service/org.wso2.micro.integrator.crypto.provider/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>crypto-service</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/crypto-service/pom.xml
+++ b/components/crypto-service/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>mi-component-parent</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.capp.deployer/pom.xml
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.capp.deployer/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>data-services</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.common/pom.xml
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.common/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>data-services</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.core/pom.xml
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>data-services</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.odata.endpoint/pom.xml
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.odata.endpoint/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>data-services</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/data/data-services/org.wso2.micro.integrator.dataservices.sql.driver/pom.xml
+++ b/components/data/data-services/org.wso2.micro.integrator.dataservices.sql.driver/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>data-services</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/data/data-services/pom.xml
+++ b/components/data/data-services/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>data</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/data/pom.xml
+++ b/components/data/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>mi-component-parent</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/javax.cache/pom.xml
+++ b/components/javax.cache/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>mi-component-parent</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/mediation/data-publishers/org.wso2.micro.integrator.analytics.data.publisher.util/pom.xml
+++ b/components/mediation/data-publishers/org.wso2.micro.integrator.analytics.data.publisher.util/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>data-publishers</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/mediation/data-publishers/org.wso2.micro.integrator.analytics.messageflow.data.publisher/pom.xml
+++ b/components/mediation/data-publishers/org.wso2.micro.integrator.analytics.messageflow.data.publisher/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>data-publishers</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/mediation/data-publishers/org.wso2.micro.integrator.observability/pom.xml
+++ b/components/mediation/data-publishers/org.wso2.micro.integrator.observability/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>data-publishers</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/mediation/data-publishers/pom.xml
+++ b/components/mediation/data-publishers/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>mediation</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/mediation/extensions/org.wso2.micro.integrator.security.handlers/pom.xml
+++ b/components/mediation/extensions/org.wso2.micro.integrator.security.handlers/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>extensions</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/components/mediation/extensions/org.wso2.micro.integrator.security.handlers/utsecurity/pom.xml
+++ b/components/mediation/extensions/org.wso2.micro.integrator.security.handlers/utsecurity/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>org.wso2.micro.integrator.security.handlers</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/mediation/extensions/org.wso2.micro.integrator.transport.handlers/pom.xml
+++ b/components/mediation/extensions/org.wso2.micro.integrator.transport.handlers/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>extensions</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/mediation/extensions/pom.xml
+++ b/components/mediation/extensions/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>mediation</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint.osgi/pom.xml
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint.osgi/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <artifactId>inbound-endpoints</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint.persistence/pom.xml
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint.persistence/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>inbound-endpoints</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/pom.xml
+++ b/components/mediation/inbound-endpoints/org.wso2.micro.integrator.inbound.endpoint/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>inbound-endpoints</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/mediation/inbound-endpoints/pom.xml
+++ b/components/mediation/inbound-endpoints/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>mediation</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/mediation/mediators/cache-mediator/org.wso2.carbon.mediator.cache/pom.xml
+++ b/components/mediation/mediators/cache-mediator/org.wso2.carbon.mediator.cache/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>mediators</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/mediation/mediators/cache-mediator/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CacheMediator.java
+++ b/components/mediation/mediators/cache-mediator/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CacheMediator.java
@@ -547,11 +547,15 @@ public class CacheMediator extends AbstractMediator implements ManagedLifecycle,
                         synLog.auditWarn("Error occurred while parsing the date." + e.getMessage());
                     }
                 }
-                //Individually copying All TRANSPORT_HEADERS to headerProperties Map instead putting whole
-                //TRANSPORT_HEADERS map as single Key/Value pair to fix hazelcast serialization issue.
-                for (Map.Entry<String, String> entry : headers.entrySet()) {
-                    headerProperties.put(entry.getKey(), entry.getValue());
+
+                if(headers != null) {
+                    //Individually copying All TRANSPORT_HEADERS to headerProperties Map instead putting whole
+                    //TRANSPORT_HEADERS map as single Key/Value pair to fix hazelcast serialization issue.
+                    for (Map.Entry<String, String> entry : headers.entrySet()) {
+                        headerProperties.put(entry.getKey(), entry.getValue());
+                    }
                 }
+
                 headerProperties.put(Constants.Configuration.MESSAGE_TYPE, messageType);
                 headerProperties.put(CachingConstants.CACHE_KEY, response.getRequestHash());
                 response.setHeaderProperties(headerProperties);

--- a/components/mediation/mediators/cache-mediator/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/digest/HttpRequestHashGenerator.java
+++ b/components/mediation/mediators/cache-mediator/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/digest/HttpRequestHashGenerator.java
@@ -607,8 +607,12 @@ public class HttpRequestHashGenerator implements DigestGenerator {
                         return o1.compareToIgnoreCase(o2);
                     }
                 });
-        transportHeaders.putAll((Map<String, String>) msgContext.
-                getProperty(MessageContext.TRANSPORT_HEADERS));
+
+        Map<String, String> headers = (Map<String, String>) msgContext.getProperty(MessageContext.TRANSPORT_HEADERS);
+        if (headers != null) {
+            transportHeaders.putAll(headers);
+        }
+
         //remove permanently excluded headers from hashing methods
         for (String header : permanentlyExcludedHeaders) {
             transportHeaders.remove(header);

--- a/components/mediation/mediators/cache-mediator/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/util/HttpCachingFilter.java
+++ b/components/mediation/mediators/cache-mediator/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/util/HttpCachingFilter.java
@@ -181,10 +181,13 @@ public class HttpCachingFilter {
                 org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS);
         String cacheControlHeaderValue = null;
 
-        //Copying All TRANSPORT_HEADERS to headerProperties Map.
-        for (Map.Entry<String, String> entry : headers.entrySet()) {
-            headerProperties.put(entry.getKey(), entry.getValue());
+        if(headers != null) {
+            //Copying All TRANSPORT_HEADERS to headerProperties Map.
+            for (Map.Entry<String, String> entry : headers.entrySet()) {
+                headerProperties.put(entry.getKey(), entry.getValue());
+            }
         }
+
         if (headerProperties.get(HttpHeaders.CACHE_CONTROL) != null) {
             cacheControlHeaderValue = String.valueOf(headerProperties.get(HttpHeaders.CACHE_CONTROL));
         }

--- a/components/mediation/mediators/dataservices-mediator/org.wso2.micro.integrator.mediator.dataservice/pom.xml
+++ b/components/mediation/mediators/dataservices-mediator/org.wso2.micro.integrator.mediator.dataservice/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>mediators</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/mediation/mediators/entitlement-mediator/org.wso2.micro.integrator.identity.entitlement.mediator/pom.xml
+++ b/components/mediation/mediators/entitlement-mediator/org.wso2.micro.integrator.identity.entitlement.mediator/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mediators</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/mediation/mediators/oauth-mediator/org.wso2.micro.integrator.mediator.oauth/pom.xml
+++ b/components/mediation/mediators/oauth-mediator/org.wso2.micro.integrator.mediator.oauth/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>mediators</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/components/mediation/mediators/pom.xml
+++ b/components/mediation/mediators/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>mediation</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/mediation/pom.xml
+++ b/components/mediation/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>mi-component-parent</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/mediation/registry/org.wso2.micro.integrator.registry/pom.xml
+++ b/components/mediation/registry/org.wso2.micro.integrator.registry/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>registry</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/mediation/registry/pom.xml
+++ b/components/mediation/registry/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>mediation</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/mediation/security/org.wso2.micro.integrator.mediation.security/pom.xml
+++ b/components/mediation/security/org.wso2.micro.integrator.mediation.security/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>security</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/components/mediation/security/pom.xml
+++ b/components/mediation/security/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>mediation</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/components/mediation/startup/mediation-startup/pom.xml
+++ b/components/mediation/startup/mediation-startup/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>startup</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/mediation/startup/pom.xml
+++ b/components/mediation/startup/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>mediation</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/mediation/tasks/org.wso2.micro.integrator.mediation.ntask/pom.xml
+++ b/components/mediation/tasks/org.wso2.micro.integrator.mediation.ntask/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>tasks</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/pom.xml
+++ b/components/mediation/tasks/org.wso2.micro.integrator.ntask.core/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>tasks</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/mediation/tasks/pom.xml
+++ b/components/mediation/tasks/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>mediation</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/mediation/transports/org.wso2.micro.integrator.websocket.transport/pom.xml
+++ b/components/mediation/transports/org.wso2.micro.integrator.websocket.transport/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>transports</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/mediation/transports/pom.xml
+++ b/components/mediation/transports/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>mediation</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.micro.integrator.bootstrap/pom.xml
+++ b/components/org.wso2.micro.integrator.bootstrap/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>mi-component-parent</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.micro.integrator.coordination/pom.xml
+++ b/components/org.wso2.micro.integrator.coordination/pom.xml
@@ -20,14 +20,14 @@
     <parent>
         <artifactId>mi-component-parent</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>org.wso2.micro.integrator.coordination</artifactId>
     <packaging>bundle</packaging>
-    <version>4.5.0-m1</version>
+    <version>4.5.0-SNAPSHOT</version>
     <dependencies>
         <dependency>
             <groupId>org.wso2.ei</groupId>

--- a/components/org.wso2.micro.integrator.core/pom.xml
+++ b/components/org.wso2.micro.integrator.core/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mi-component-parent</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/pom.xml
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.management.apis/pom.xml
@@ -4,7 +4,7 @@
     <parent>
     <groupId>org.wso2.ei</groupId>
     <artifactId>org.wso2.micro.integrator.extensions</artifactId>
-    <version>4.5.0-m1</version>
+    <version>4.5.0-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.probes/pom.xml
+++ b/components/org.wso2.micro.integrator.extensions/org.wso2.micro.integrator.probes/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>org.wso2.micro.integrator.extensions</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.micro.integrator.extensions/pom.xml
+++ b/components/org.wso2.micro.integrator.extensions/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mi-component-parent</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.micro.integrator.initializer/pom.xml
+++ b/components/org.wso2.micro.integrator.initializer/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mi-component-parent</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.micro.integrator.log4j2.plugins/pom.xml
+++ b/components/org.wso2.micro.integrator.log4j2.plugins/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mi-component-parent</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.micro.integrator.logging.updater/pom.xml
+++ b/components/org.wso2.micro.integrator.logging.updater/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mi-component-parent</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.micro.integrator.ndatasource.capp.deployer/pom.xml
+++ b/components/org.wso2.micro.integrator.ndatasource.capp.deployer/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mi-component-parent</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.micro.integrator.ndatasource.common/pom.xml
+++ b/components/org.wso2.micro.integrator.ndatasource.common/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mi-component-parent</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.micro.integrator.ndatasource.core/pom.xml
+++ b/components/org.wso2.micro.integrator.ndatasource.core/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mi-component-parent</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.micro.integrator.ndatasource.rdbms/pom.xml
+++ b/components/org.wso2.micro.integrator.ndatasource.rdbms/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mi-component-parent</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.micro.integrator.security/pom.xml
+++ b/components/org.wso2.micro.integrator.security/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mi-component-parent</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.micro.integrator.server/pom.xml
+++ b/components/org.wso2.micro.integrator.server/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mi-component-parent</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/org.wso2.micro.integrator.utils/pom.xml
+++ b/components/org.wso2.micro.integrator.utils/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mi-component-parent</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/components/pom.xml
+++ b/components/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>wso2-micro-integrator-parent</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>wso2-micro-integrator-parent</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/crypto-feature/org.wso2.micro.integrator.crypto.feature/pom.xml
+++ b/features/crypto-feature/org.wso2.micro.integrator.crypto.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>micro-integrator-features</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/data-features/data-services-feature/org.wso2.micro.integrator.dataservices.server.feature/pom.xml
+++ b/features/data-features/data-services-feature/org.wso2.micro.integrator.dataservices.server.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>data-services-feature</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/data-features/data-services-feature/pom.xml
+++ b/features/data-features/data-services-feature/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>data-features</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/data-features/pom.xml
+++ b/features/data-features/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>micro-integrator-features</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/mediation-features/builtin-mediators/org.wso2.micro.integrator.mediators.server.feature/pom.xml
+++ b/features/mediation-features/builtin-mediators/org.wso2.micro.integrator.mediators.server.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>builtin-mediators</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/mediation-features/builtin-mediators/pom.xml
+++ b/features/mediation-features/builtin-mediators/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mediation-features</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/mediation-features/data-publisher-features/org.wso2.micro.integrator.analytics.messageflow.data.publisher.feature/pom.xml
+++ b/features/mediation-features/data-publisher-features/org.wso2.micro.integrator.analytics.messageflow.data.publisher.feature/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>data-publisher-features</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/mediation-features/data-publisher-features/org.wso2.micro.integrator.observability.feature/pom.xml
+++ b/features/mediation-features/data-publisher-features/org.wso2.micro.integrator.observability.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>data-publisher-features</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/mediation-features/data-publisher-features/pom.xml
+++ b/features/mediation-features/data-publisher-features/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>mediation-features</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/mediation-features/dataservice-mediator-feature/org.wso2.micro.integrator.mediator.dataservice/pom.xml
+++ b/features/mediation-features/dataservice-mediator-feature/org.wso2.micro.integrator.mediator.dataservice/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>mediation-features</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/mediation-features/entitlement-mediator-feature/org.wso2.micro.integrator.identity.xacml.mediator/pom.xml
+++ b/features/mediation-features/entitlement-mediator-feature/org.wso2.micro.integrator.identity.xacml.mediator/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>mediation-features</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/features/mediation-features/inbound-endpoint/org.wso2.micro.integrator.inbound.endpoints.server.feature/pom.xml
+++ b/features/mediation-features/inbound-endpoint/org.wso2.micro.integrator.inbound.endpoints.server.feature/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <artifactId>inbound-endpoint</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/mediation-features/inbound-endpoint/pom.xml
+++ b/features/mediation-features/inbound-endpoint/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>mediation-features</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/mediation-features/ntask-feature/pom.xml
+++ b/features/mediation-features/ntask-feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>mediation-features</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/mediation-features/pom.xml
+++ b/features/mediation-features/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>micro-integrator-features</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/mediation-features/security-features/org.wso2.micro.integrator.security.server.feature/pom.xml
+++ b/features/mediation-features/security-features/org.wso2.micro.integrator.security.server.feature/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>security-features</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/mediation-features/security-features/pom.xml
+++ b/features/mediation-features/security-features/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mediation-features</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/mediation-features/transport-features/org.wso2.micro.integrator.websocket.feature/pom.xml
+++ b/features/mediation-features/transport-features/org.wso2.micro.integrator.websocket.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>transport-features</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/mediation-features/transport-features/pom.xml
+++ b/features/mediation-features/transport-features/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>mediation-features</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/features/org.wso2.micro.integrator.initializer.feature/pom.xml
+++ b/features/org.wso2.micro.integrator.initializer.feature/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>micro-integrator-features</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.micro.integrator.logging.updater.feature/pom.xml
+++ b/features/org.wso2.micro.integrator.logging.updater.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>micro-integrator-features</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.micro.integrator.ntask.core.feature/pom.xml
+++ b/features/org.wso2.micro.integrator.ntask.core.feature/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>micro-integrator-features</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/org.wso2.micro.integrator.server.feature/pom.xml
+++ b/features/org.wso2.micro.integrator.server.feature/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>micro-integrator-features</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/pom.xml
+++ b/features/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>wso2-micro-integrator-parent</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/features/wso2mi-hl7/pom.xml
+++ b/features/wso2mi-hl7/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>micro-integrator-features</artifactId>
         <groupId>org.wso2.ei</groupId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/integration/automation-extensions/pom.xml
+++ b/integration/automation-extensions/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>micro-integrator-integration-test</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/dataservice-hosting-tests/pom.xml
+++ b/integration/dataservice-hosting-tests/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>micro-integrator-integration-test</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/dataservice-hosting-tests/samples/data-services/clients/pom.xml
+++ b/integration/dataservice-hosting-tests/samples/data-services/clients/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>dataservices-samples-parent</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/dataservice-hosting-tests/samples/data-services/pom.xml
+++ b/integration/dataservice-hosting-tests/samples/data-services/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mi-samples-parent</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/dataservice-hosting-tests/samples/pom.xml
+++ b/integration/dataservice-hosting-tests/samples/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>dataservice-integration</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/dataservice-hosting-tests/tests-common/admin-clients/pom.xml
+++ b/integration/dataservice-hosting-tests/tests-common/admin-clients/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>dataservice-integration-tests-common</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/dataservice-hosting-tests/tests-common/integration-test-utils/pom.xml
+++ b/integration/dataservice-hosting-tests/tests-common/integration-test-utils/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>dataservice-integration-tests-common</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/dataservice-hosting-tests/tests-common/pom.xml
+++ b/integration/dataservice-hosting-tests/tests-common/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>dataservice-integration</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/dataservice-hosting-tests/tests-integration/pom.xml
+++ b/integration/dataservice-hosting-tests/tests-integration/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>dataservice-integration</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/dataservice-hosting-tests/tests-integration/tests/pom.xml
+++ b/integration/dataservice-hosting-tests/tests-integration/tests/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>dataservice-integration-tests</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/management-api-tests/pom.xml
+++ b/integration/management-api-tests/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>micro-integrator-integration-test</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/mediation-tests/coverage-report/pom.xml
+++ b/integration/mediation-tests/coverage-report/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mediation-integration</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/mediation-tests/pom.xml
+++ b/integration/mediation-tests/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>micro-integrator-integration-test</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/mediation-tests/service-samples/pom.xml
+++ b/integration/mediation-tests/service-samples/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mediation-integration</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/mediation-tests/tests-http/pom.xml
+++ b/integration/mediation-tests/tests-http/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mediation-integration</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/mediation-tests/tests-mediator-1/pom.xml
+++ b/integration/mediation-tests/tests-mediator-1/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mediation-integration</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/mediation-tests/tests-mediator-2/pom.xml
+++ b/integration/mediation-tests/tests-mediator-2/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mediation-integration</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/mediation-tests/tests-other/pom.xml
+++ b/integration/mediation-tests/tests-other/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mediation-integration</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/mediation-tests/tests-patches-with-smb2/pom.xml
+++ b/integration/mediation-tests/tests-patches-with-smb2/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mediation-integration</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/mediation-tests/tests-patches/pom.xml
+++ b/integration/mediation-tests/tests-patches/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mediation-integration</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/mediation-tests/tests-platform/pom.xml
+++ b/integration/mediation-tests/tests-platform/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mediation-integration</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/mediation-tests/tests-platform/tests-coordination/pom.xml
+++ b/integration/mediation-tests/tests-platform/tests-coordination/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mediation-integration</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/integration/mediation-tests/tests-platform/tests-rabbitmq/pom.xml
+++ b/integration/mediation-tests/tests-platform/tests-rabbitmq/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>org.wso2.carbon.ei.tests.platform</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/mediation-tests/tests-platform/tests-userstore/pom.xml
+++ b/integration/mediation-tests/tests-platform/tests-userstore/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mediation-integration</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/integration/mediation-tests/tests-sample/pom.xml
+++ b/integration/mediation-tests/tests-sample/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mediation-integration</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/mediation-tests/tests-service/pom.xml
+++ b/integration/mediation-tests/tests-service/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mediation-integration</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/mediation-tests/tests-transport-2/pom.xml
+++ b/integration/mediation-tests/tests-transport-2/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mediation-integration</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/mediation-tests/tests-transport/pom.xml
+++ b/integration/mediation-tests/tests-transport/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mediation-integration</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>wso2-micro-integrator-parent</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/samples/product/pom.xml
+++ b/integration/samples/product/pom.xml
@@ -22,7 +22,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>micro-integrator-integration-test</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/integration/tests-common/admin-clients/pom.xml
+++ b/integration/tests-common/admin-clients/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>integration-test-common</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/tests-common/integration-test-utils/pom.xml
+++ b/integration/tests-common/integration-test-utils/pom.xml
@@ -8,7 +8,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>integration-test-common</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/tests-common/pom.xml
+++ b/integration/tests-common/pom.xml
@@ -4,7 +4,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>micro-integrator-integration-test</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/p2-profile/pom.xml
+++ b/p2-profile/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>wso2-micro-integrator-parent</artifactId>
-        <version>4.5.0-m1</version>
+        <version>4.5.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     <groupId>org.wso2.ei</groupId>
     <artifactId>wso2-micro-integrator-parent</artifactId>
     <packaging>pom</packaging>
-    <version>4.5.0-m1</version>
+    <version>4.5.0-SNAPSHOT</version>
     <name>WSO2 Micro Integrator</name>
     <url>http://wso2.com/products/enterprise-integrator/</url>
     <description>WSO2 Micro Integrator</description>
@@ -1305,7 +1305,7 @@
             <dependency>
                 <groupId>org.wso2.ei</groupId>
                 <artifactId>org.wso2.micro.integrator.coordination</artifactId>
-                <version>4.5.0-m1</version>
+                <version>4.5.0-SNAPSHOT</version>
             </dependency>
             <!--SAP feature dependency-->
             <dependency>
@@ -1555,7 +1555,7 @@
         <url>https://github.com/wso2/micro-integrator.git</url>
         <developerConnection>scm:git:https://github.com/wso2/micro-integrator.git</developerConnection>
         <connection>scm:git:https://github.com/wso2/micro-integrator.git</connection>
-        <tag>v4.5.0-m1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <profiles>


### PR DESCRIPTION
## Purpose
I encountered a `NullPointerException` while developing an API where the `CacheMediator` is used immediately after the `TRANSPORT_HEADERS` property has been removed.

Here is a sample API configuration that reproduces the issue (tested with Micro Integrator 4.4.0):

```xml
<?xml version="1.0" encoding="UTF-8"?>
<api xmlns="http://ws.apache.org/ns/synapse" name="test" context="/test">
    <resource methods="GET" uri-template="/test">
        <inSequence>
            <cache collector="false" maxMessageSize="1000" timeout="600">
                <onCacheHit />
                <protocol type="HTTP">
                    <methods>GET</methods>
                    <headersToExcludeInHash />
                    <headersToIncludeInHash />
                    <responseCodes>200</responseCodes>
                    <enableCacheControl>false</enableCacheControl>
                    <includeAgeHeader>true</includeAgeHeader>
                    <hashGenerator>org.wso2.carbon.mediator.cache.digest.HttpRequestHashGenerator</hashGenerator>
                </protocol>
                <implementation maxSize="100" />
            </cache>
            <payloadFactory media-type="json">
                <format>{"example": true}</format>
            </payloadFactory>
            <loopback />
        </inSequence>
        <outSequence>
            <property name="TRANSPORT_HEADERS" scope="axis2" action="remove" />
            <cache collector="true"></cache>
            <send />
        </outSequence>
    </resource>
</api>
```

```bash
curl -v http://localhost:8290/test/test
```

This configuration causes the following NPE:

```text
[2025-09-03 22:41:10,639] ERROR {SequenceMediator} - {api:test} Cannot invoke "java.util.Map.entrySet()" because "headers" is null java.lang.NullPointerException: Cannot invoke "java.util.Map.entrySet()" because "headers" is null
        at org.wso2.carbon.mediator.cache.CacheMediator.processResponseMessage(CacheMediator.java:552)
        at org.wso2.carbon.mediator.cache.CacheMediator.mediate(CacheMediator.java:251)
        at org.apache.synapse.mediators.AbstractListMediator.mediate(AbstractListMediator.java:132)
        at org.apache.synapse.mediators.AbstractListMediator.mediate(AbstractListMediator.java:79)
        at org.apache.synapse.mediators.base.SequenceMediator.mediate(SequenceMediator.java:158)
        at org.apache.synapse.api.Resource.process(Resource.java:342)
        at org.apache.synapse.api.API.process(API.java:420)
        at org.apache.synapse.api.AbstractApiHandler.apiProcess(AbstractApiHandler.java:95)
        at org.apache.synapse.api.AbstractApiHandler.dispatchToAPI(AbstractApiHandler.java:73)
        at org.apache.synapse.api.rest.RestRequestHandler.dispatchToAPI(RestRequestHandler.java:90)
        at org.apache.synapse.api.rest.RestRequestHandler.process(RestRequestHandler.java:63)
        at org.apache.synapse.rest.RESTRequestHandler.process(RESTRequestHandler.java:54)
        at org.apache.synapse.core.axis2.Axis2SynapseEnvironment.injectMessage(Axis2SynapseEnvironment.java:352)
        at org.apache.synapse.mediators.builtin.LoopBackMediator.mediate(LoopBackMediator.java:65)
        at org.apache.synapse.mediators.AbstractListMediator.mediate(AbstractListMediator.java:132)
        at org.apache.synapse.mediators.AbstractListMediator.mediate(AbstractListMediator.java:79)
        at org.apache.synapse.mediators.base.SequenceMediator.mediate(SequenceMediator.java:158)
        at org.apache.synapse.api.Resource.process(Resource.java:342)
        at org.apache.synapse.api.API.process(API.java:476)
        at org.apache.synapse.api.AbstractApiHandler.apiProcess(AbstractApiHandler.java:95)
        at org.apache.synapse.api.AbstractApiHandler.dispatchToAPI(AbstractApiHandler.java:73)
        at org.apache.synapse.api.rest.RestRequestHandler.dispatchToAPI(RestRequestHandler.java:90)
        at org.apache.synapse.api.rest.RestRequestHandler.process(RestRequestHandler.java:76)
        at org.apache.synapse.rest.RESTRequestHandler.process(RESTRequestHandler.java:54)
        at org.apache.synapse.core.axis2.Axis2SynapseEnvironment.injectMessage(Axis2SynapseEnvironment.java:352)
        at org.apache.synapse.core.axis2.SynapseMessageReceiver.receive(SynapseMessageReceiver.java:101)
        at org.apache.axis2.engine.AxisEngine.receive(AxisEngine.java:180)
        at org.apache.synapse.transport.passthru.ServerWorker.processNonEntityEnclosingRESTHandler(ServerWorker.java:401)
        at org.apache.synapse.transport.passthru.ServerWorker.run(ServerWorker.java:215)
        at org.apache.axis2.transport.base.threads.NativeWorkerPool$1.run(NativeWorkerPool.java:172)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1583)
```

## Goals
The goal is to fix the `NullPointerException` that occurs in the `CacheMediator` when the `TRANSPORT_HEADERS` property is missing.

## Approach
I've added a null check in `CacheMediator` to safely handle cases where the transport headers are not present. Similar defensive checks have been added to other affected classes (`HttpRequestHashGenerator`, `HttpCachingFilter`) to prevent related issues.