### PR TITLE
Fix NPE in CacheMediator while TRANSPORT_HEADERS removed

### DIFF
--- a/components/mediation/mediators/cache-mediator/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CacheMediator.java
+++ b/components/mediation/mediators/cache-mediator/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/CacheMediator.java
@@ -547,11 +547,15 @@ public class CacheMediator extends AbstractMediator implements ManagedLifecycle,
                         synLog.auditWarn("Error occurred while parsing the date." + e.getMessage());
                     }
                 }
-                //Individually copying All TRANSPORT_HEADERS to headerProperties Map instead putting whole
-                //TRANSPORT_HEADERS map as single Key/Value pair to fix hazelcast serialization issue.
-                for (Map.Entry<String, String> entry : headers.entrySet()) {
-                    headerProperties.put(entry.getKey(), entry.getValue());
+
+                if(headers != null) {
+                    //Individually copying All TRANSPORT_HEADERS to headerProperties Map instead putting whole
+                    //TRANSPORT_HEADERS map as single Key/Value pair to fix hazelcast serialization issue.
+                    for (Map.Entry<String, String> entry : headers.entrySet()) {
+                        headerProperties.put(entry.getKey(), entry.getValue());
+                    }
                 }
+
                 headerProperties.put(Constants.Configuration.MESSAGE_TYPE, messageType);
                 headerProperties.put(CachingConstants.CACHE_KEY, response.getRequestHash());
                 response.setHeaderProperties(headerProperties);

--- a/components/mediation/mediators/cache-mediator/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/digest/HttpRequestHashGenerator.java
+++ b/components/mediation/mediators/cache-mediator/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/digest/HttpRequestHashGenerator.java
@@ -607,8 +607,12 @@ public class HttpRequestHashGenerator implements DigestGenerator {
                         return o1.compareToIgnoreCase(o2);
                     }
                 });
-        transportHeaders.putAll((Map<String, String>) msgContext.
-                getProperty(MessageContext.TRANSPORT_HEADERS));
+
+        Map<String, String> headers = (Map<String, String>) msgContext.getProperty(MessageContext.TRANSPORT_HEADERS);
+        if (headers != null) {
+            transportHeaders.putAll(headers);
+        }
+
         //remove permanently excluded headers from hashing methods
         for (String header : permanentlyExcludedHeaders) {
             transportHeaders.remove(header);

--- a/components/mediation/mediators/cache-mediator/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/util/HttpCachingFilter.java
+++ b/components/mediation/mediators/cache-mediator/org.wso2.carbon.mediator.cache/src/main/java/org/wso2/carbon/mediator/cache/util/HttpCachingFilter.java
@@ -181,10 +181,13 @@ public class HttpCachingFilter {
                 org.apache.axis2.context.MessageContext.TRANSPORT_HEADERS);
         String cacheControlHeaderValue = null;
 
-        //Copying All TRANSPORT_HEADERS to headerProperties Map.
-        for (Map.Entry<String, String> entry : headers.entrySet()) {
-            headerProperties.put(entry.getKey(), entry.getValue());
+        if(headers != null) {
+            //Copying All TRANSPORT_HEADERS to headerProperties Map.
+            for (Map.Entry<String, String> entry : headers.entrySet()) {
+                headerProperties.put(entry.getKey(), entry.getValue());
+            }
         }
+
         if (headerProperties.get(HttpHeaders.CACHE_CONTROL) != null) {
             cacheControlHeaderValue = String.valueOf(headerProperties.get(HttpHeaders.CACHE_CONTROL));
         }


### PR DESCRIPTION
## Purpose
I encountered a `NullPointerException` while developing an API where the `CacheMediator` is used immediately after the `TRANSPORT_HEADERS` property has been removed.

Here is a sample API configuration that reproduces the issue (tested with Micro Integrator 4.4.0):

```xml
<?xml version="1.0" encoding="UTF-8"?>
<api xmlns="http://ws.apache.org/ns/synapse" name="test" context="/test">
    <resource methods="GET" uri-template="/test">
        <inSequence>
            <cache collector="false" maxMessageSize="1000" timeout="600">
                <onCacheHit />
                <protocol type="HTTP">
                    <methods>GET</methods>
                    <headersToExcludeInHash />
                    <headersToIncludeInHash />
                    <responseCodes>200</responseCodes>
                    <enableCacheControl>false</enableCacheControl>
                    <includeAgeHeader>true</includeAgeHeader>
                    <hashGenerator>org.wso2.carbon.mediator.cache.digest.HttpRequestHashGenerator</hashGenerator>
                </protocol>
                <implementation maxSize="100" />
            </cache>
            <payloadFactory media-type="json">
                <format>{"example": true}</format>
            </payloadFactory>
            <loopback />
        </inSequence>
        <outSequence>
            <property name="TRANSPORT_HEADERS" scope="axis2" action="remove" />
            <cache collector="true"></cache>
            <send />
        </outSequence>
    </resource>
</api>
```

```bash
curl -v http://localhost:8290/test/test
```

This configuration causes the following NPE:

```text
[2025-09-03 22:41:10,639] ERROR {SequenceMediator} - {api:test} Cannot invoke "java.util.Map.entrySet()" because "headers" is null java.lang.NullPointerException: Cannot invoke "java.util.Map.entrySet()" because "headers" is null
        at org.wso2.carbon.mediator.cache.CacheMediator.processResponseMessage(CacheMediator.java:552)
        at org.wso2.carbon.mediator.cache.CacheMediator.mediate(CacheMediator.java:251)
        at org.apache.synapse.mediators.AbstractListMediator.mediate(AbstractListMediator.java:132)
        at org.apache.synapse.mediators.AbstractListMediator.mediate(AbstractListMediator.java:79)
        at org.apache.synapse.mediators.base.SequenceMediator.mediate(SequenceMediator.java:158)
        at org.apache.synapse.api.Resource.process(Resource.java:342)
        at org.apache.synapse.api.API.process(API.java:420)
        at org.apache.synapse.api.AbstractApiHandler.apiProcess(AbstractApiHandler.java:95)
        at org.apache.synapse.api.AbstractApiHandler.dispatchToAPI(AbstractApiHandler.java:73)
        at org.apache.synapse.api.rest.RestRequestHandler.dispatchToAPI(RestRequestHandler.java:90)
        at org.apache.synapse.api.rest.RestRequestHandler.process(RestRequestHandler.java:63)
        at org.apache.synapse.rest.RESTRequestHandler.process(RESTRequestHandler.java:54)
        at org.apache.synapse.core.axis2.Axis2SynapseEnvironment.injectMessage(Axis2SynapseEnvironment.java:352)
        at org.apache.synapse.mediators.builtin.LoopBackMediator.mediate(LoopBackMediator.java:65)
        at org.apache.synapse.mediators.AbstractListMediator.mediate(AbstractListMediator.java:132)
        at org.apache.synapse.mediators.AbstractListMediator.mediate(AbstractListMediator.java:79)
        at org.apache.synapse.mediators.base.SequenceMediator.mediate(SequenceMediator.java:158)
        at org.apache.synapse.api.Resource.process(Resource.java:342)
        at org.apache.synapse.api.API.process(API.java:476)
        at org.apache.synapse.api.AbstractApiHandler.apiProcess(AbstractApiHandler.java:95)
        at org.apache.synapse.api.AbstractApiHandler.dispatchToAPI(AbstractApiHandler.java:73)
        at org.apache.synapse.api.rest.RestRequestHandler.dispatchToAPI(RestRequestHandler.java:90)
        at org.apache.synapse.api.rest.RestRequestHandler.process(RestRequestHandler.java:76)
        at org.apache.synapse.rest.RESTRequestHandler.process(RESTRequestHandler.java:54)
        at org.apache.synapse.core.axis2.Axis2SynapseEnvironment.injectMessage(Axis2SynapseEnvironment.java:352)
        at org.apache.synapse.core.axis2.SynapseMessageReceiver.receive(SynapseMessageReceiver.java:101)
        at org.apache.axis2.engine.AxisEngine.receive(AxisEngine.java:180)
        at org.apache.synapse.transport.passthru.ServerWorker.processNonEntityEnclosingRESTHandler(ServerWorker.java:401)
        at org.apache.synapse.transport.passthru.ServerWorker.run(ServerWorker.java:215)
        at org.apache.axis2.transport.base.threads.NativeWorkerPool$1.run(NativeWorkerPool.java:172)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
        at java.base/java.lang.Thread.run(Thread.java:1583)
```

## Goals
The goal is to fix the `NullPointerException` that occurs in the `CacheMediator` when the `TRANSPORT_HEADERS` property is missing.

## Approach
I've added a null check in `CacheMediator` to safely handle cases where the transport headers are not present. Similar defensive checks have been added to other affected classes (`HttpRequestHashGenerator`, `HttpCachingFilter`) to prevent related issues.