### PR TITLE
Add default access control for script mediator

### DIFF
--- a/distribution/src/resources/config-tool/default.json
+++ b/distribution/src/resources/config-tool/default.json
@@ -95,6 +95,10 @@
   "synapse_properties.'analytics.endpoint_analytics.enabled'": true,
   "synapse_properties.'analytics.inbound_endpoint_analytics.enabled'": true,
 
+  "synapse_properties.'limit_java_class_access_in_scripts.enable'": true,
+  "synapse_properties.'limit_java_class_access_in_scripts.list_type'": "BLOCK_LIST",
+  "synapse_properties.'limit_java_class_access_in_scripts.class_prefixes'": "java.lang,java.io,java.nio,java.net",
+
   "passthru_properties.'http.socket.timeout'": "180000",
   "passthru_properties.'worker_pool_size_core'": "400",
   "passthru_properties.'secondary_worker_pool_size_core'": "400",


### PR DESCRIPTION
## Purpose

Add default access control for script mediator

```
[synapse_properties]
'limit_java_class_access_in_scripts.enable' = true
'limit_java_class_access_in_scripts.list_type' = "BLOCK_LIST"
'limit_java_class_access_in_scripts.class_prefixes' = "java.lang,java.io,java.nio,java.net"
```