### PR TITLE
Exclude bouncycastle in test common utils

### DIFF
--- a/integration/tests-common/pom.xml
+++ b/integration/tests-common/pom.xml
@@ -271,6 +271,14 @@
                     <groupId>org.bouncycastle</groupId>
                     <artifactId>bcprov-jdk15on</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcpkix-jdk18on</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.bouncycastle</groupId>
+                    <artifactId>bcutil-jdk18on</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1647,7 +1647,7 @@
         <version.jaxb.api>2.4.0-b180830.0359</version.jaxb.api>
         <com.sun.jaxb.version>2.3.0</com.sun.jaxb.version>
         <com.sun.jaxb.impl.version>2.3.1</com.sun.jaxb.impl.version>
-        <synapse.version>4.0.0-wso2v252</synapse.version>
+        <synapse.version>4.0.0-wso2v257</synapse.version>
         <imp.pkg.version.synapse>[4.0.0, 4.0.1)</imp.pkg.version.synapse>
         <carbon.mediation.version>4.7.260</carbon.mediation.version>
         <carbon.crypto.version>1.1.3</carbon.crypto.version>


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

$subject

With the upgrade of bouncycastle dependencies in synapse, there are test failures due to the certificate verification failing from Httpclients. This PR will exclude BC dependencies from test-common module.